### PR TITLE
Add model caching and image resizing

### DIFF
--- a/TagFlow.py
+++ b/TagFlow.py
@@ -844,7 +844,8 @@ class ImageTaggingTab(QWidget):
             "clean_patterns": loaded_config.get("clean_patterns", {
                 "initial": default_initial_patterns,
                 "additional": default_additional_patterns
-            })
+            }),
+            "max_image_size": loaded_config.get("max_image_size", 1024),
         }
         self.analyzer = None
         self.worker = None
@@ -1162,6 +1163,7 @@ class ImageTaggingTab(QWidget):
         self.settings["model"] = self.model_combo.currentText()
         self.settings["api_url"] = self.url_edit.text()
         self.settings["use_japanese"] = self.japanese_check.isChecked()
+        save_app_config(self.settings)
 
         # アナライザ生成
         self.analyzer = ImageAnalyzer(
@@ -1171,7 +1173,8 @@ class ImageTaggingTab(QWidget):
             custom_prompt=self.settings["custom_prompt"] if self.settings["custom_prompt"] else None,
             clean_custom_response=self.settings["clean_response"],
             api_url=self.settings["api_url"],
-            clean_patterns=self.settings["clean_patterns"]
+            clean_patterns=self.settings["clean_patterns"],
+            max_size=self.settings["max_image_size"],
         )
 
         # ワーカースレッド開始

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 Pillow
 PySide6
-pillow_heif
+pillow-heif

--- a/tagflow/__init__.py
+++ b/tagflow/__init__.py
@@ -5,6 +5,7 @@ from .utils import (
     load_app_config,
     save_app_config,
     apply_clean_patterns,
+    fetch_latest_models,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "load_app_config",
     "save_app_config",
     "apply_clean_patterns",
+    "fetch_latest_models",
 ]

--- a/tagflow/analyzer.py
+++ b/tagflow/analyzer.py
@@ -25,6 +25,7 @@ class ImageAnalyzer:
         clean_custom_response=True,
         api_url="http://localhost:11434/api/generate",
         clean_patterns=None,
+        max_size=None,
     ):
         self.model = model
         self.use_japanese = use_japanese
@@ -32,6 +33,7 @@ class ImageAnalyzer:
         self.custom_prompt = custom_prompt
         self.clean_custom_response = clean_custom_response
         self.api_url = api_url
+        self.max_size = max_size
         self.supported_formats = {
             ".jpg",
             ".jpeg",
@@ -51,11 +53,14 @@ class ImageAnalyzer:
         """Pillowで画像を開きBase64にエンコード"""
         try:
             with Image.open(image_path) as img:
+                if self.max_size:
+                    resample = getattr(Image, "Resampling", Image).LANCZOS
+                    img.thumbnail((self.max_size, self.max_size), resample)
                 img_buffer = io.BytesIO()
                 save_format = img.format if img.format else "PNG"
-            if save_format.upper() == "HEIF":
-                save_format = "PNG"
-            img.save(img_buffer, format=save_format)
+                if save_format.upper() == "HEIF":
+                    save_format = "PNG"
+                img.save(img_buffer, format=save_format)
             return base64.b64encode(img_buffer.getvalue()).decode("utf-8")
         except Exception as e:
             logger.error(f"画像エンコードエラー: {e}")

--- a/tagflow/utils.py
+++ b/tagflow/utils.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import re
+import time
 from pathlib import Path
+
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -101,13 +104,25 @@ def apply_clean_patterns(text, patterns):
     parts = [part.strip() for part in text.split(',') if part.strip() and not part.startswith('、')]
     return ', '.join(parts)
 
-def fetch_latest_models(url="https://ollama.ai/library"):
+def fetch_latest_models(url="https://ollama.ai/library", use_cache=True, cache_duration=3600):
     """Ollamaライブラリページからモデル一覧を取得"""
+    config = load_app_config() if use_cache else {}
+    cache = config.get("model_cache", {})
+    if use_cache:
+        timestamp = cache.get("timestamp", 0)
+        if time.time() - timestamp < cache_duration and cache.get("models"):
+            return cache["models"]
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
-        models = re.findall(r'x-test-model-title title="([^"]+)"', response.text)
-        return sorted(set(models))
+        models = sorted(set(re.findall(r'x-test-model-title title="([^"]+)"', response.text)))
+        if use_cache:
+            config["model_cache"] = {
+                "timestamp": time.time(),
+                "models": models,
+            }
+            save_app_config(config)
+        return models
     except Exception as e:
         logger.warning(f"モデル一覧取得エラー: {e}")
-        return []
+        return cache.get("models", [])


### PR DESCRIPTION
## Summary
- cache model list in `app_config.json` to avoid redundant network requests
- support optional image resizing before analysis
- persist tagging settings and correct requirements

## Testing
- `python -m py_compile TagFlow.py tagflow/utils.py tagflow/analyzer.py tagflow/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689582a1c724832f907c4d1b859fcdf9